### PR TITLE
fixed typos: no parantheses around exceptions, no b infront of binary data

### DIFF
--- a/phstl.py
+++ b/phstl.py
@@ -65,7 +65,7 @@ class stlwriter():
 		self.written = 0
 		
 		# write binary stl header with predicted facet count
-		self.f.write('\0' * 80)
+		self.f.write(b'\0' * 80)
 		# (facet count is little endian 4 byte unsigned int)
 		self.f.write(pack('<I', facet_count))
 	
@@ -78,7 +78,7 @@ class stlwriter():
 		for vertex in t:
 			self.f.write(pack('<3f', *vertex))
 		# facet records conclude with two null bytes (unused "attributes")
-		self.f.write('\0\0')
+		self.f.write(b'\0\0')
 		self.written += 1
 	
 	def done(self):
@@ -122,7 +122,7 @@ args = ap.parse_args()
 
 try:
 	img = gdal.Open(args.RASTER)
-except RuntimeError, e:
+except (RuntimeError, e):
 	fail(str(e).strip())
 
 # input raster dimensions


### PR DESCRIPTION
first error:

```

$ ./phstl.py 
  File "/home/nandor/tmp/phstl/./phstl.py", line 125
    except RuntimeError, e:
           ^^^^^^^^^^^^^^^
SyntaxError: multiple exception types must be parenthesize

```

after inserting parantheses:

```
$ ./phstl.py demo/example.tif out.stl
Traceback (most recent call last):
  File "/home/nandor/tmp/phstl/./phstl.py", line 308, in <module>
    with stlwriter(args.STL, facetcount) as mesh:
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nandor/tmp/phstl/./phstl.py", line 68, in __init__
    self.f.write('\0' * 80)
TypeError: a bytes-like object is required, not 'str'

```

after inserting `b'\0'` instead of `'\0'`

```

$ ./phstl.py demo/example.tif out.stl
Traceback (most recent call last):
  File "/home/nandor/tmp/phstl/./phstl.py", line 354, in <module>
    mesh.add_facet((a, b, c))
  File "/home/nandor/tmp/phstl/./phstl.py", line 81, in add_facet
    self.f.write('\0\0')
TypeError: a bytes-like object is required, not 'str'
```

after inserting `b'\0'` instead of `'\0\0'`, it runs

maybe my system is weird, or some python update broke something, i dont know. just letting you know, that this pr fixes it for me, and it works again